### PR TITLE
fixed rect to draw when called in certain ways

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -166,7 +166,7 @@ function api.rect(x0, y0, x1, y1, col)
 	if col then
 		color(col)
 	end
-	love.graphics.rectangle("line", flr(x0)+1, flr(y0)+1, flr(x1-x0), flr(y1-y0))
+	love.graphics.rectangle("line", flr(x0), flr(y0), flr(x1-x0)+1, flr(y1-y0)+1)
 end
 
 function api.rectfill(x0, y0, x1, y1, col)


### PR DESCRIPTION
code from Invader Overload
http://www.lexaloffle.com/bbs/?tid=4004
http://www.lexaloffle.com/bbs/cposts/2/26413.p8.png

uses to draw its normal shot bullets:

``` lua
                rect(obj.pos.x,obj.pos.y, obj.pos.x,obj.pos.y-3, 7)
                rect(obj.pos.x+1,obj.pos.y, obj.pos.x+1,obj.pos.y-3, 0)
```

old picolove code drew no bullets:

``` lua
    love.graphics.rectangle("line", flr(x0)+1, flr(y0)+1, flr(x1-x0), flr(y1-y0))
```

this new code now draws bullets:

``` lua
    love.graphics.rectangle("line", flr(x0), flr(y0), flr(x1-x0)+1, flr(y1-y0)+1)
```

(I simply made it look more like the picolove rectfill code)
