### PR TITLE
Ensure atan2(0,0) returns 0.75 like official PICO-8.

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -728,7 +728,7 @@ end
 api.sqrt=math.sqrt
 
 function api.atan2(x, y)
-	return math.atan2(-y,x) / (math.pi * 2) % 1.0
+	return (0.75 + math.atan2(x,y) / (math.pi * 2)) % 1.0
 end
 
 function api.band(x, y)


### PR DESCRIPTION
Smee again! I’m afraid I realised my previous change proposal was not fully compliant with official PICO-8 because of the behaviour in `(0,0)`, it should return `0.75`.
