### PR TITLE
Add map() default arguments

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -410,12 +410,12 @@ end
 
 function api.map(cel_x, cel_y, sx, sy, cel_w, cel_h, bitmask)
 	love.graphics.setShader(pico8.sprite_shader)
-	cel_x=flr(cel_x)
-	cel_y=flr(cel_y)
-	sx=flr(sx)
-	sy=flr(sy)
-	cel_w=flr(cel_w)
-	cel_h=flr(cel_h)
+	cel_x=flr(cel_x or 0)
+	cel_y=flr(cel_y or 0)
+	sx=flr(sx or 0)
+	sy=flr(sy or 0)
+	cel_w=flr(cel_w or 128)
+	cel_h=flr(cel_h or 64)
 	for y=0, cel_h-1 do
 		if cel_y+y<64 and cel_y+y>=0 then
 			for x=0, cel_w-1 do


### PR DESCRIPTION
I'm not sure if it's documented anywhere, but PICO-8's `map()` has default arguments that dumps the entire map to the screen.