### PR TITLE
Add dummy placeholder for menuitem()

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -1097,6 +1097,9 @@ function api.holdframe()
 	-- TODO: Implement this
 end
 
+function api.menuitem()
+end
+
 api.sub=string.sub
 api.pairs=pairs
 api.type=type


### PR DESCRIPTION
Although the menu doesn't seem to be implemented, it'd be nice if carts calling `menuitem()` could still be loaded.