### PR TITLE
Enable console in config, to make printh() work

### DIFF
--- a/conf.lua
+++ b/conf.lua
@@ -6,4 +6,6 @@ function love.conf(t)
 	t.window.width=580
 	t.window.height=540
 	t.window.resizable=true
+
+	t.console=true
 end


### PR DESCRIPTION
As far as I can tell, this is needed to make `printh()` calls in cartridges actually do anything.